### PR TITLE
Fix deprecation warnings since nuxt 1.0.0

### DIFF
--- a/template/nuxt/nuxt.config.js
+++ b/template/nuxt/nuxt.config.js
@@ -84,7 +84,7 @@ module.exports = {
     */
     extend(config, ctx) {
       <% if (eslint === 'yes') { %>// Run ESLint on save
-      if (ctx.isDev && ctx.isClient) {
+      if (ctx.isDev && process.client) {
         config.module.rules.push({
           enforce: 'pre',
           test: /\.(js|vue)$/,
@@ -92,7 +92,7 @@ module.exports = {
           exclude: /(node_modules)/
         })
       }<% } %><% if (ui === 'vuetify') { %>
-      if (ctx.isServer) {
+      if (process.server) {
         config.externals = [
           nodeExternals({
             whitelist: [/^vuetify/]


### PR DESCRIPTION
BTW, could someone guide me to the documentation which explains what's the difference between `client` and `server` in the `nuxt.config.js` file?

Is `client` used with `nuxt generate` whereas `server` is used with `nuxt build`?