### PR TITLE
Fix Vuetify 1.0.0 color declaration error.

### DIFF
--- a/template/frameworks/vuetify/plugins/vuetify.js
+++ b/template/frameworks/vuetify/plugins/vuetify.js
@@ -8,7 +8,7 @@ Vue.use(Vuetify, {
     accent: colors.grey.darken3,
     secondary: colors.amber.darken3,
     info: colors.teal.lighten1,
-    warning: colors.amber,
+    warning: colors.amber.base,
     error: colors.deepOrange.accent4,
     success: colors.green.accent3
   }


### PR DESCRIPTION
When upgrading Vuetify to version `1.0.0-beta.5`, I received the error "Colors can only be numbers or strings, recieved Object instead". That error is caused by the usage of `colors.amber`, which is an object.