### PR TITLE
cross-env dependency in NODE_ENV=production

### DIFF
--- a/template/_package.json
+++ b/template/_package.json
@@ -41,10 +41,10 @@
     "@nuxtjs/bulma": "^1.0.3"<% } else if (ui === 'element-ui') { %>,
     "element-ui": "^2.2.1"<% } else if (ui === 'buefy') { %>,
     "nuxt-buefy": "^0.0.4"<% } %><% if (axios === 'yes') { %>,
-    "@nuxtjs/axios": "^5.0.0"<% } %>
+    "@nuxtjs/axios": "^5.0.0"<% } %>,
+    "cross-env": "^5.0.1"<% if (eslint === 'yes') { %>
   },
   "devDependencies": {
-    "cross-env": "^5.0.1"<% if (eslint === 'yes') { %>,
     "babel-eslint": "^8.2.1",
     "eslint": "^5.0.1",
     "eslint-loader": "^2.0.0",

--- a/template/_package.json
+++ b/template/_package.json
@@ -17,7 +17,8 @@
     "precommit": "npm run lint"<% } %>
   },
   "dependencies": {
-    "nuxt": "^1.0.0"<% if (server === 'express') { %>,
+    "cross-env": "^5.0.1",
+    "nuxt": "^1.4.2"<% if (server === 'express') { %>,
     "express": "^4.15.3"<% } else if (server === 'koa') { %>,
     "koa": "^2.3.0"<% } else if (server === 'hapi') { %>,
     "hapi-nuxt": "^0.6.0"<% } else if (server === 'micro') { %>,
@@ -41,10 +42,9 @@
     "@nuxtjs/bulma": "^1.0.3"<% } else if (ui === 'element-ui') { %>,
     "element-ui": "^2.2.1"<% } else if (ui === 'buefy') { %>,
     "nuxt-buefy": "^0.0.4"<% } %><% if (axios === 'yes') { %>,
-    "@nuxtjs/axios": "^5.0.0"<% } %>,
-    "cross-env": "^5.0.1"<% if (eslint === 'yes') { %>
+    "@nuxtjs/axios": "^5.0.0"<% } %>
   },
-  "devDependencies": {
+  "devDependencies": {<% if (eslint === 'yes') { %>
     "babel-eslint": "^8.2.1",
     "eslint": "^5.0.1",
     "eslint-loader": "^2.0.0",


### PR DESCRIPTION
When I run:

```bash
npm i --production && npm start
```

I got this error:

```
sh: 1: cross-env: not found
```

Therefore I think `cross-env` should be placed in `"dependencies"`.