### PR TITLE
fix miss nuxt-edge module error

### DIFF
--- a/template/server/index-koa.js
+++ b/template/server/index-koa.js
@@ -1,7 +1,7 @@
 
 const Koa = require('koa')
 const consola = require('consola')
-const { Nuxt, Builder } = require('nuxt-edge')
+const { Nuxt, Builder } = require('nuxt')
 
 const app = new Koa()
 const host = process.env.HOST || '127.0.0.1'


### PR DESCRIPTION
server uses nuxt-edge module, but installed nuxt, so app crashed when npm start