### PR TITLE
No "-edge" needed. Nuxt 2 is live

### DIFF
--- a/template/server/index-express.js
+++ b/template/server/index-express.js
@@ -1,7 +1,7 @@
 
 const express = require('express')
 const consola = require('consola')
-const { Nuxt, Builder } = require('nuxt-edge')
+const { Nuxt, Builder } = require('nuxt')
 const app = express()
 const host = process.env.HOST || '127.0.0.1'
 const port = process.env.PORT || 3000


### PR DESCRIPTION
Otherwise the package nuxt-edge is not found when the server is starting