### PR TITLE
fix: Cannot find module 'nuxt-edge'

### DIFF
--- a/template/frameworks/adonis/app/Controllers/Http/NuxtController.js
+++ b/template/frameworks/adonis/app/Controllers/Http/NuxtController.js
@@ -2,7 +2,7 @@
 
 const Env = use('Env')
 const Config = use('Config')
-const { Nuxt, Builder } = require('nuxt-edge')
+const { Nuxt, Builder } = require('nuxt')
 
 class NuxtController {
   constructor() {

--- a/template/frameworks/feathers/server/middleware/nuxt.js
+++ b/template/frameworks/feathers/server/middleware/nuxt.js
@@ -1,5 +1,5 @@
 const resolve = require('path').resolve
-const { Nuxt, Builder } = require('nuxt-edge')
+const { Nuxt, Builder } = require('nuxt')
 
 // Setup nuxt.js
 let config = {}

--- a/template/frameworks/micro/server/micro.config.js
+++ b/template/frameworks/micro/server/micro.config.js
@@ -1,5 +1,5 @@
 const dispatch = require('micro-route/dispatch')
-const { Nuxt, Builder } = require('nuxt-edge')
+const { Nuxt, Builder } = require('nuxt')
 
 // Require nuxt config
 const config = require('../nuxt.config.js')

--- a/template/server/index-express.js
+++ b/template/server/index-express.js
@@ -1,7 +1,7 @@
 
 const express = require('express')
 const consola = require('consola')
-const { Nuxt, Builder } = require('nuxt-edge')
+const { Nuxt, Builder } = require('nuxt')
 const app = express()
 const host = process.env.HOST || '127.0.0.1'
 const port = process.env.PORT || 3000

--- a/template/server/index-koa.js
+++ b/template/server/index-koa.js
@@ -1,7 +1,7 @@
 
 const Koa = require('koa')
 const consola = require('consola')
-const { Nuxt, Builder } = require('nuxt-edge')
+const { Nuxt, Builder } = require('nuxt')
 
 const app = new Koa()
 const host = process.env.HOST || '127.0.0.1'


### PR DESCRIPTION
With Nuxt 2.0's release, the `nuxt-edge` dependency is invalid. Changed server template imports to reflect that. Taking into account previous PRs regarding this issue, I've omitted changes from those.