### PR TITLE
fix: tailwind dependency

### DIFF
--- a/template/_package.json
+++ b/template/_package.json
@@ -51,7 +51,7 @@
     "eslint-loader": "^2.0.0",
     "eslint-plugin-vue": "^4.0.0"<% } %><% if (ui === 'tailwind') { %>,
     "autoprefixer": "^8.6.4",
-    "tailwindcss": "^0.6.5"<% } else if (ui === 'vuetify') { %>,
+    "tailwindcss": "~0.6.6"<% } else if (ui === 'vuetify') { %>,
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.1"<% } %>
   }

--- a/template/nuxt/pages/index.vue
+++ b/template/nuxt/pages/index.vue
@@ -33,6 +33,14 @@ export default {
 </script>
 
 <style>
+<% if (ui === 'tailwind') { %>
+/* Sample `apply` at-rules with Tailwind CSS
+.container
+{
+  @apply min-h-screen flex justify-center items-center text-center;
+}
+*/
+<% } %>
 .container
 {
   min-height: 100vh;


### PR DESCRIPTION
Tailwind v0.6.6 allows `@apply` rules in `.vue` single file components so I thought upgrading it as the base version would be beneficial.

However, there are syntax errors from the linter when implementing postcss imports inside components, so adding `<style lang="postcss">` fixes that. In doing that, we'd need to add that test in `nuxt.config.js` with [these rules](https://github.com/nuxt/nuxt.js/issues/3231#issuecomment-381885334) as well.